### PR TITLE
Add $ANDROID_SDK/ to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ gen/
 # Gradle files
 .gradle/
 build/
+$ANDROID_SDK/
 
 # Local configuration file (sdk path, etc)
 local.properties


### PR DESCRIPTION
The path $ANDROID_SDK/ is generated when using gradle, this gitignore update makes sure this doesnt get included in the repo.

(Fixed)