### PR TITLE
Adds PokeGoApi as Gradle Dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,12 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
+        debug {
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
@@ -36,13 +40,15 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile group: 'com.google.protobuf.nano', name: 'protobuf-javanano', version: '3.0.0-alpha-5'
+    compile 'com.github.Grover-c13:PokeGOAPI-Java:master-SNAPSHOT'
+
+  compile group: 'com.google.protobuf.nano', name: 'protobuf-javanano', version: '3.0.0-alpha-5'
     compile 'com.android.support:appcompat-v7:24.0.0'
     compile 'com.android.support:design:24.0.0'
     compile 'com.android.support:support-v4:24.0.0'
     compile 'com.google.android.gms:play-services-maps:9.2.1'
     compile 'com.google.android.gms:play-services-location:9.2.1'
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+//    compile 'com.squareup.okhttp3:okhttp:3.4.1'
     compile 'com.github.franmontiel:PersistentCookieJar:v0.9.3'
     compile 'com.squareup.retrofit2:retrofit:2.0.0'
     compile 'com.squareup.retrofit2:converter-gson:2.0.0'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -15,3 +15,62 @@
 #-keepclassmembers class fqcn.of.javascript.interface.for.webview {
 #   public *;
 #}
+
+-printseeds build/seed.txt
+-printusage build/usuage.txt
+
+-dontobfuscate
+-dontusemixedcaseclassnames
+-dontskipnonpubliclibraryclasses
+-dontskipnonpubliclibraryclassmembers
+-dontpreverify
+-optimizationpasses 5
+
+-keepattributes Signature, InnerClasses, EnclosingMethod, *Annotation*
+
+#####
+# Something to do with Okio.Http
+#####
+-dontwarn java.nio.file.Files
+-dontwarn java.nio.file.Path
+-dontwarn java.nio.file.OpenOption
+-dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
+-keep, includedescriptorclasses class sun.misc.Unsafe { *; }
+
+
+######
+# Support Stream
+######
+#-dontwarn java.lang.invoke.**
+-dontwarn sun.misc.Unsafe
+-dontwarn java.lang.**
+
+######
+# App Compat, Design Support Libraries
+######
+-keep, includedescriptorclasses public class android.support.v7.widget.** { *; }
+-keep public class android.support.v7.internal.widget.** { *; }
+-keep public class android.support.v7.internal.view.menu.** { *; }
+-dontwarn android.support.design.**
+-keep, includedescriptorclasses class android.support.design.** { *; }
+-keep interface android.support.design.** { *; }
+-keep, includedescriptorclasses public class android.support.design.R$* { *; }
+
+
+#####
+# Protocol Buffers
+#####
+-keep class com.google.protobuf.** { *; }
+-dontwarn com.google.**
+-keep class * extends com.google.protobuf.GeneratedMessage { *; }
+-keepclassmembernames class * extends com.google.protobuf.GeneratedMessage { *; }
+
+
+-keep class java8.**
+-dontwarn java8.**
+
+-keep, includedescriptorclasses public class POGOSProtos.**{ *; }
+-keep, includedescriptorclasses public class com.omkarmoghe.**{ *; }
+
+
+#-ignorewarnings


### PR DESCRIPTION
This api is still in active development, so I ended up using there jar dependency they put on jitpack.io. Here is the [repo](https://github.com/Grover-c13/PokeGOAPI-Java).  Due to all of there dependencies and our existing proto classes I ran into dexing issues therefore had to add a proguard file.
