### PR TITLE
Added missing prev ids to getNeighbors()

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/network/NianticManager.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/network/NianticManager.java
@@ -310,7 +310,9 @@ public class NianticManager {
 
         for (int i = 1; i <= 10; i++) {
             Integer next = origin + i;
+            Integer prev = origin - i;
             walk.add(next);
+            walk.add(prev);
         }
 
         Collections.sort(walk);


### PR DESCRIPTION
So, after reading the getNeighbors() method from py again. I saw that I skipped the previous ids in this method.
