### PR TITLE
Add logout option

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/MainActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/MainActivity.java
@@ -48,16 +48,20 @@ public class MainActivity extends BaseActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        int id = item.getItemId();
-        if (id == R.id.action_settings) {
-            startActivity(new Intent(this, SettingsActivity.class));
-        } else if (id == R.id.action_relogin) {
-            login();
+        switch(item.getItemId()) {
+            case R.id.action_settings:
+                startActivity(new Intent(this, SettingsActivity.class));
+                break;
+            case R.id.action_relogin:
+                login();
+                break;
+            case R.id.action_logout:
+                logout();
+                break;
         }
 
         return super.onOptionsItemSelected(item);
     }
-
 
     private void login() {
         if (!pref.isUsernameSet() || !pref.isPasswordSet()) {
@@ -65,6 +69,21 @@ public class MainActivity extends BaseActivity {
         } else {
             nianticManager.login(pref.getUsername(), pref.getPassword(), this);
         }
+    }
+
+    private void logout() {
+        pref.removeUsername();
+        pref.removePassword();
+        reloadActivity();
+    }
+
+    private void reloadActivity() {
+        Intent intent = getIntent();
+        overridePendingTransition(0, 0);
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        finish();
+        overridePendingTransition(0, 0);
+        startActivity(intent);
     }
 
     private void requestLoginCredentials() {

--- a/app/src/main/java/com/omkarmoghe/pokemap/app_preferences/PokemapAppPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/app_preferences/PokemapAppPreferences.java
@@ -27,6 +27,11 @@ public interface PokemapAppPreferences {
     void setUsername(@NonNull String username);
 
     /**
+     * Remove username associated with account.
+     */
+    void removeUsername();
+
+    /**
      * @param password that should be set
      */
     void setPassword(@NonNull String password);
@@ -35,4 +40,10 @@ public interface PokemapAppPreferences {
      * @return the password stored or an empty @see java.lang.String
      */
     String getPassword();
+
+
+    /**
+     * Remove password associated with account
+     */
+    void removePassword();
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/app_preferences/PokemapSharedPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/app_preferences/PokemapSharedPreferences.java
@@ -41,6 +41,11 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
     }
 
     @Override
+    public void removeUsername() {
+        sharedPreferences.edit().remove(USERNAME_KEY).apply();
+    }
+
+    @Override
     public void setPassword(@NonNull String password) {
         sharedPreferences.edit().putString(PASSWORD_KEY, password).apply();
     }
@@ -49,4 +54,10 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
     public String getPassword() {
         return sharedPreferences.getString(PASSWORD_KEY, "");
     }
+
+    @Override
+    public void removePassword() {
+        sharedPreferences.edit().remove(PASSWORD_KEY).apply();
+    }
+
 }

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -6,4 +6,6 @@
         android:title="@string/action_settings" app:showAsAction="never" />
     <item android:id="@+id/action_relogin" android:orderInCategory="200"
         android:title="@string/action_relogin" app:showAsAction="never" />
+    <item android:id="@+id/action_logout" android:orderInCategory="300"
+        android:title="@string/action_logout" app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,4 +25,5 @@
     <string name="title_activity_poke_map">Pokemon Nearby</string>
 
     <string name="request_credentials_title">Insert your Pokemon Go credentials</string>
+    <string name="action_logout">Logout</string>
 </resources>


### PR DESCRIPTION
Small commit that adds a logout option. This removes the username and password from SharedPreferences, and restarts the main activity (to reset map / other variables and bring up the login prompt again). In the future, a separate Login Activity should be added so that restarting the main activity is not necessary.
