### PR TITLE
information about build pre-requisites in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ We're still testing and haven't merged it into this repo yet.
 # PRs - please follow the [Android style guides & best practices](https://source.android.com/source/code-style.html)
 ## All PRs should go to the `dev` branch. `master` will be updated periodically with stable(ish) releases.
 
+## [Building] (https://github.com/omkarmoghe/Pokemap/wiki/Building)
+Make sure you use the latest [android studio version 2.2 (canary builds)] (http://tools.android.com/download/studio/canary/latest) and have installed the latest versions of the build tools and support libraries in order to successfully compile and run the project. 
+
 ## [TODO](https://slack-files.com/T1TQY34KE-F1TSY25UL-10400392c2)
 Please read through the main repo to see how the Python code is grabbing the spawned Pokemon, etc. We need to recreate that functionality in Java :D.
 


### PR DESCRIPTION
In reference to #103 
The fact that this project needs an android studio 2.2+ (canary release) could be mentioned clearly, since it is not a stable release yet and lot of people may not have it yet. Many of these people might not check the wiki before forking and building this project.

Hence, I suggest adding this small note and link to the build pre-requisites in readme.md
