### PR TITLE
Screen orientation fix for map

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentTransaction;
 import android.support.v7.widget.Toolbar;
 import android.util.Log;
@@ -29,6 +30,8 @@ import org.greenrobot.eventbus.Subscribe;
 
 public class MainActivity extends BaseActivity {
     private static final String TAG = "Pokemap";
+    private static final String MAP_FRAGMENT_TAG = "MapFragment";
+
 
     private PokemapAppPreferences pref;
 
@@ -44,9 +47,12 @@ public class MainActivity extends BaseActivity {
         Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        FragmentTransaction transaction = getSupportFragmentManager().beginTransaction();
-        transaction.replace(R.id.main_container, MapWrapperFragment.newInstance())
-                .addToBackStack(null)
+        FragmentManager fragmentManager = getSupportFragmentManager();
+        MapWrapperFragment mapWrapperFragment = (MapWrapperFragment) fragmentManager.findFragmentByTag(MAP_FRAGMENT_TAG);
+        if(mapWrapperFragment == null) {
+            mapWrapperFragment = MapWrapperFragment.newInstance();
+        }
+        fragmentManager.beginTransaction().replace(R.id.main_container,mapWrapperFragment, MAP_FRAGMENT_TAG)
                 .commit();
     }
 

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -79,8 +79,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        if (getArguments() != null) {
-        }
         setRetainInstance(true);
     }
 

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -81,7 +81,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
         super.onCreate(savedInstanceState);
         if (getArguments() != null) {
         }
-        EventBus.getDefault().register(this);
+        setRetainInstance(true);
     }
 
     @Override
@@ -110,6 +110,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
         if (mSupportMapFragment == null) {
             mSupportMapFragment = SupportMapFragment.newInstance();
             getChildFragmentManager().beginTransaction().replace(R.id.map, mSupportMapFragment).commit();
+            mSupportMapFragment.setRetainInstance(true);
         }
 
         if (mGoogleMap == null) {


### PR DESCRIPTION
Fix for  #69 

The map is not recreated after a configuration change. Used fragment's setRetainInstance(true) to ensure map wrapper fragment and its state is persisted across recreated activities.
