### PR TITLE
Persist markers between scans and remove the expired ones

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/models/PokemonMarkerExtended.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/models/PokemonMarkerExtended.java
@@ -1,0 +1,35 @@
+package com.omkarmoghe.pokemap.models;
+
+import com.pokegoapi.api.map.pokemon.CatchablePokemon;
+import com.google.android.gms.maps.model.Marker;
+
+/**
+ * Created by socrates on 7/24/2016.
+ */
+public class PokemonMarkerExtended {
+
+
+    private CatchablePokemon catchablePokemon;
+    private Marker marker;
+
+    public PokemonMarkerExtended(CatchablePokemon catchablePokemon, Marker marker) {
+        this.catchablePokemon = catchablePokemon;
+        this.marker = marker;
+    }
+
+    public CatchablePokemon getCatchablePokemon() {
+        return catchablePokemon;
+    }
+
+    public void setCatchablePokemon(CatchablePokemon catchablePokemon) {
+        this.catchablePokemon = catchablePokemon;
+    }
+
+    public Marker getMarker() {
+        return marker;
+    }
+
+    public void setMarker(Marker marker) {
+        this.marker = marker;
+    }
+}

--- a/app/src/main/java/com/omkarmoghe/pokemap/models/map/PokemonMarkerExtended.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/models/map/PokemonMarkerExtended.java
@@ -1,4 +1,4 @@
-package com.omkarmoghe.pokemap.models;
+package com.omkarmoghe.pokemap.models.map;
 
 import com.pokegoapi.api.map.pokemon.CatchablePokemon;
 import com.google.android.gms.maps.model.Marker;

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -181,12 +181,11 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
 
     private void updatePokemonMarkers() {
         if (mGoogleMap != null && markerList != null && !markerList.isEmpty()){
-            long minExpiration = 900000;
             for(Iterator<Map.Entry<String, PokemonMarkerExtended>> it = markerList.entrySet().iterator(); it.hasNext(); ) {
                 Map.Entry<String, PokemonMarkerExtended> entry = it.next();
                 CatchablePokemon catchablePokemon = entry.getValue().getCatchablePokemon();
                 Marker marker = entry.getValue().getMarker();
-                long millisLeft = catchablePokemon.getExpirationTimestampMs() < 0 ? 900000 : catchablePokemon.getExpirationTimestampMs() - System.currentTimeMillis(); // Sometimes expiration comes as a negative -1, default 15min expiration
+                long millisLeft = catchablePokemon.getExpirationTimestampMs() - System.currentTimeMillis();
                 if(millisLeft < 0) {
                     marker.remove();
                     it.remove();
@@ -196,8 +195,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                         marker.showInfoWindow();
                     }
                 }
-
-                minExpiration = millisLeft < minExpiration ? millisLeft : minExpiration;
             }
 
         }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -207,8 +207,8 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     private void setPokemonMarkers(final List<CatchablePokemon> pokeList){
         if (mGoogleMap != null) {
 
-
             Set<String> markerKeys = markerList.keySet();
+            int pokemonFound = 0;
             for (CatchablePokemon poke : pokeList) {
 
                 if(!markerKeys.contains(poke.getSpawnPointId())) {
@@ -221,8 +221,12 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
 
                     //adding pokemons to list to be removed on next search
                     markerList.put(poke.getSpawnPointId(), new PokemonMarkerExtended(poke, marker));
+                    pokemonFound++;
                 }
             }
+
+            MainActivity.toast.setText(pokemonFound > 0 ? pokemonFound + " new catchable Pokemon have been found." : "No new Pokemon have been found.");
+            MainActivity.toast.show();
 
             updatePokemonMarkers();
         } else {
@@ -251,9 +255,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     @Subscribe(threadMode = ThreadMode.MAIN)
     public void onEvent(CatchablePokemonEvent event) {
 
-//        Toast.makeText(getContext(), event.getCatchablePokemon().size() + " new catchable Pokemon have been found.", Toast.LENGTH_LONG).show();
-        MainActivity.toast.setText(event.getCatchablePokemon().size() + " new catchable Pokemon have been found.");
-        MainActivity.toast.show();
         setPokemonMarkers(event.getCatchablePokemon());
     }
 

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -27,7 +27,7 @@ import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 import com.omkarmoghe.pokemap.R;
 import com.omkarmoghe.pokemap.controllers.map.LocationManager;
-import com.omkarmoghe.pokemap.models.PokemonMarkerExtended;
+import com.omkarmoghe.pokemap.models.map.PokemonMarkerExtended;
 import com.omkarmoghe.pokemap.models.events.CatchablePokemonEvent;
 import com.omkarmoghe.pokemap.models.events.SearchInPosition;
 import com.omkarmoghe.pokemap.views.MainActivity;
@@ -37,7 +37,6 @@ import org.greenrobot.eventbus.EventBus;
 import org.greenrobot.eventbus.Subscribe;
 import org.greenrobot.eventbus.ThreadMode;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;


### PR DESCRIPTION
- Add pokemon markers to a hashmap to keep track of all the previous scans
- Update marker snipper with current expiration, added a update markers method
- Call the update markers on resume and after scanning
- Change scanning location marker to a smaller one
- Center pokemon markers
- Check permissions to set my location
