### PR TITLE
Remove marker selection/information presentation after long press

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -183,7 +183,6 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                         .snippet("Dissapears in: " + getDurationBreakdown(millisLeft))
                         .icon(BitmapDescriptorFactory.fromResource(resourceID)));
 
-                marker.showInfoWindow();
                 //adding pokemons to list to be removed on next search
                 markerList.add(marker);
             }


### PR DESCRIPTION
Removes annoying auto popup marker selection/information presentation after long press
Before you had to dismiss the auto popup before you can select the location behind it as well as it could hide potential pokemon behind it. 
This has now been resolved.
