### PR TITLE
Google login only one-time

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapAppPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapAppPreferences.java
@@ -35,4 +35,10 @@ public interface PokemapAppPreferences {
      * @return the password stored or an empty @see java.lang.String
      */
     String getPassword();
+
+    boolean isGoogleTokenAvailable();
+
+    String getGoogleToken();
+
+    void setGoogleToken(@NonNull String token);
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapSharedPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapSharedPreferences.java
@@ -12,6 +12,7 @@ import android.support.annotation.NonNull;
 public final class PokemapSharedPreferences implements PokemapAppPreferences {
     private static final String USERNAME_KEY = "UsernameKey";
     private static final String PASSWORD_KEY = "PasswordKey";
+    private static final String GOOGLE_TOKEN_KEY = "GoogleTokenKey";
 
     private final SharedPreferences sharedPreferences;
 
@@ -48,5 +49,20 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
     @Override
     public String getPassword() {
         return sharedPreferences.getString(PASSWORD_KEY, "");
+    }
+
+    @Override
+    public boolean isGoogleTokenAvailable() {
+        return sharedPreferences.contains(GOOGLE_TOKEN_KEY);
+    }
+
+    @Override
+    public String getGoogleToken() {
+        return sharedPreferences.getString(GOOGLE_TOKEN_KEY, "");
+    }
+
+    @Override
+    public void setGoogleToken(@NonNull String token) {
+        sharedPreferences.edit().putString(GOOGLE_TOKEN_KEY, token).apply();
     }
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/LoginActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/LoginActivity.java
@@ -63,6 +63,9 @@ public class LoginActivity extends AppCompatActivity{
         if (mPref.isUsernameSet() && mPref.isPasswordSet()) {
             mNianticManager.login(mPref.getUsername(), mPref.getPassword());
             finishLogin();
+        } else if (mPref.isGoogleTokenAvailable()) {
+            mNianticManager.setGoogleAuthToken(mPref.getGoogleToken());
+            finishLogin();
         }
 
         setContentView(R.layout.activity_login);
@@ -88,6 +91,7 @@ public class LoginActivity extends AppCompatActivity{
             @Override
             public void authSuccessful(String authToken) {
                 showProgress(false);
+                mPref.setGoogleToken(authToken);
                 Log.d(TAG, "authSuccessful() called with: authToken = [" + authToken + "]");
                 mNianticManager.setGoogleAuthToken(authToken);
                 finishLogin();


### PR DESCRIPTION
Use google login only one time. Use the authentication token obtained from google login and store it in shared preferences. Check google token in shared preferences, and if available, use it for google login

TODO: handle google auth token expiry. Not sure if this is needed though.
