### PR TITLE
Prevent sending events to service

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
@@ -330,13 +330,9 @@ public class NianticManager {
                 try {
                     EventBus.getDefault().post(new PokestopsEvent(pokemonGo.getMap().getMapObjects().getPokestops()));
                 } catch (LoginFailedException e) {
-                    e.printStackTrace();
-                    Log.e(TAG, "Failed to fetch map information via getMapInformation(). Login credentials wrong or user banned. Raised: " + e.getMessage());
-                    EventBus.getDefault().post(new LoginEventResult(false, null, null));
+                    handleFailedLogin(e);
                 } catch (RemoteServerException e) {
-                    e.printStackTrace();
-                    Log.e(TAG, "Failed to fetch map information via getMapInformation(). Remote server unreachable. Raised: " + e.getMessage());
-                    EventBus.getDefault().post(new ServerUnreachableEvent(e));
+                    handleRemoteServerException(e);
                 }
             }
         },
@@ -346,19 +342,27 @@ public class NianticManager {
                 try {
                     EventBus.getDefault().post(new CatchablePokemonEvent(pokemonGo.getMap().getCatchablePokemon(),pokemonGo.getLatitude(),pokemonGo.getLongitude()));
                 } catch (LoginFailedException e) {
-                    e.printStackTrace();
-                    Log.e(TAG, "Failed to fetch map information via getMapInformation(). Login credentials wrong or user banned. Raised: " + e.getMessage());
-                    EventBus.getDefault().post(new LoginEventResult(false, null, null));
+                    handleFailedLogin(e);
                 } catch (RemoteServerException e) {
-                    e.printStackTrace();
-                    Log.e(TAG, "Failed to fetch map information via getMapInformation(). Remote server unreachable. Raised: " + e.getMessage());
-                    EventBus.getDefault().post(new ServerUnreachableEvent(e));
+                    handleRemoteServerException(e);
                 }
 
             }
         };
 
         public abstract void sendEvent(PokemonGo pokemonGo);
+
+        private static void handleFailedLogin(LoginFailedException e) {
+            e.printStackTrace();
+            Log.e(TAG, "Failed to fetch map information via getMapInformation(). Login credentials wrong or user banned. Raised: " + e.getMessage());
+            EventBus.getDefault().post(new LoginEventResult(false, null, null));
+        }
+
+        private static void handleRemoteServerException(RemoteServerException e) {
+            e.printStackTrace();
+            Log.e(TAG, "Failed to fetch map information via getMapInformation(). Remote server unreachable. Raised: " + e.getMessage());
+            EventBus.getDefault().post(new ServerUnreachableEvent(e));
+        }
     }
 
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/service/PokemonNotificationService.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/service/PokemonNotificationService.java
@@ -167,7 +167,7 @@ public class PokemonNotificationService extends Service{
                     LatLng currentLocation = locationManager.getLocation();
 
                     if(currentLocation != null){
-                        nianticManager.getMapInformation(currentLocation.latitude,currentLocation.longitude,0);
+                        nianticManager.getMapInformation(currentLocation.latitude,currentLocation.longitude,0, NianticManager.RequestedMapEvents.POKEMON);
                     }else {
                         locationManager = LocationManager.getInstance(PokemonNotificationService.this);
                     }


### PR DESCRIPTION
If events are being sent that the application currently inst listing for it spams the logcat, which probably is bad but in any case makes debugging difficult.

This is my suggest for a more dynamic way to control which events the get all sends and to prevent too much code duplication.

There is a handy sendAll that uses the default signature from before.
