### PR TITLE
typo in disclaimer message fixed

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/views/LoginActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/LoginActivity.java
@@ -129,7 +129,7 @@ public class LoginActivity extends AppCompatActivity{
             public void onClick(View view) {
                 new AlertDialog.Builder(LoginActivity.this)
                         .setTitle(getString(R.string.login_warning_title))
-                        .setMessage(Html.fromHtml(getString(R.string.login_warning) + "<b>"+getString(R.string.ban)+"</b>"))
+                        .setMessage(Html.fromHtml(getString(R.string.login_warning) + " "+ "<b>"+getString(R.string.ban)+"</b>" + "."))
                         .setPositiveButton(android.R.string.ok, null)
                         .show();
             }


### PR DESCRIPTION
There was no space in between last two words of message i.e being and banned. I have fixed that in this PR.

**Email**:vishwajeets912@gmail.com 
