### PR TITLE
Grand stability upgrade #3

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapAppPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapAppPreferences.java
@@ -47,4 +47,8 @@ public interface PokemapAppPreferences {
     Set<PokemonIdOuterClass.PokemonId> getShowablePokemonIDs();
 
     void setShowablePokemonIDs(Set<PokemonIdOuterClass.PokemonId> pokemonIDs);
+
+    void setShowMapSuggestion(boolean showMapSuggestion);
+
+    boolean getShowMapSuggestion();
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapSharedPreferences.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/app_preferences/PokemapSharedPreferences.java
@@ -38,6 +38,7 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
     private static final String SERVICE_REFRESH_KEY = "service_refresh_rate";
     private static final String POKEMONS_TO_SHOW = "pokemons_to_show";
     private static final String STEPS = "search_steps";
+    private static final String SHOW_MAP_SUGGESTION = "show_map_suggestion";
 
     private static final String INFO_TOKEN = "token=";
     private static final String INFO_REFRESH = "refresh=";
@@ -170,7 +171,7 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
 
     @Override
     public boolean getShowLuredPokemon() {
-        return sharedPreferences.getBoolean(SHOW_LURED, false);
+        return sharedPreferences.getBoolean(SHOW_LURED, true);
     }
 
     public Set<PokemonIdOuterClass.PokemonId> getShowablePokemonIDs() {
@@ -197,6 +198,16 @@ public final class PokemapSharedPreferences implements PokemapAppPreferences {
             showablePokemonStringIDs.add(String.valueOf(pokemonId.getNumber()));
         }
         sharedPreferences.edit().putStringSet(POKEMONS_TO_SHOW, showablePokemonStringIDs).apply();
+    }
+
+    @Override
+    public void setShowMapSuggestion(boolean showMapSuggestion) {
+        sharedPreferences.edit().putBoolean(SHOW_MAP_SUGGESTION, showMapSuggestion).apply();
+    }
+
+    @Override
+    public boolean getShowMapSuggestion() {
+        return sharedPreferences.getBoolean(SHOW_MAP_SUGGESTION, true);
     }
 
     @Override

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
@@ -184,7 +184,7 @@ public class NianticManager {
             @Override
             public void onResponse(Call<NianticService.LoginResponse> call, Response<NianticService.LoginResponse> response) {
                 String location = response.headers().get("location");
-                if (location != null) {
+                if (location != null && location.split("ticket=").length > 0) {
                     String ticket = location.split("ticket=")[1];
                     requestToken(ticket, loginListener);
                 } else {

--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/service/PokemonNotificationService.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/service/PokemonNotificationService.java
@@ -39,6 +39,8 @@ public class PokemonNotificationService extends Service{
     private static final int notificationId = 2423235;
     private static final String ACTION_STOP_SELF = "com.omkarmoghe.pokemap.STOP_SERVICE";
 
+    public static boolean isRunning = false;
+
     private UpdateRunnable updateRunnable;
     private Thread workThread;
     private LocationManager locationManager;
@@ -57,6 +59,8 @@ public class PokemonNotificationService extends Service{
 
     @Override
     public void onCreate() {
+
+        isRunning = true;
 
         EventBus.getDefault().register(this);
         createNotification();
@@ -90,6 +94,7 @@ public class PokemonNotificationService extends Service{
         updateRunnable.stop();
         EventBus.getDefault().unregister(this);
         unregisterReceiver(mBroadcastReciever);
+        isRunning = false;
     }
 
     @Override
@@ -205,4 +210,8 @@ public class PokemonNotificationService extends Service{
             locationManager.onPause();
         }
     };
+
+    public static boolean isRunning() {
+        return isRunning;
+    }
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/MainActivity.java
@@ -170,6 +170,12 @@ public class MainActivity extends BaseActivity {
     }
 
     private void startNotificationService(){
+
+        // check for if the service is already running
+        if (PokemonNotificationService.isRunning()) {
+            stopNotificationService();
+        }
+
         Intent intent = new Intent(this, PokemonNotificationService.class);
         startService(intent);
     }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/settings/SettingsActivity.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/settings/SettingsActivity.java
@@ -42,10 +42,4 @@ public class SettingsActivity extends AppCompatActivity {
             recreate();
         }
     }
-
-    @Override
-    public void onBackPressed() {
-        super.onBackPressed();
-        NavUtils.navigateUpFromSameTask(this);
-    }
 }


### PR DESCRIPTION
- The NotificationService now doesn't start multiple instances anymore -- there only once service instance at a time. probably fixed #270, probably #208
- Now the NotificationService doesn't call getCatchablePokemon() every 60ms (Uff..., and this bug  was for multiple instances before and interacted with the EventBus...!); probably fixed #270, #246 
- Fixed two crashes (ArrayOutOfBounds, NullPointer), fixes #219, probably #166
- Fixed Snackbar shows up after returning from SettingsActivity (also doesn't search & zoom in) -- it just shows the map at the location you are at the moment., fixes #218
- Map suggestion remembers that you closed it. Never shows up again.
