### PR TITLE
Removed the second layer cache from RemoteImageLoader

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/helpers/RemoteImageLoader.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/helpers/RemoteImageLoader.java
@@ -9,37 +9,27 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.request.animation.GlideAnimation;
 import com.bumptech.glide.request.target.SimpleTarget;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * Cache wrapper around the Glide image loader.
+ * 29.07.16: for now, the second layer cache is removed, caching is handled by Glide.
  * <p>
  * Created by aronhomberg on 26.07.16.
  */
 public class RemoteImageLoader {
 
-    private static Map<String, Bitmap> bitmapCache = new HashMap<>();
-
     public static void load(final String url, int pxWidth, int pxHeight,
                             Drawable placeholderDrawable, Context context, final Callback onFetch) {
-        // ultra-fast cache reply
-        if (bitmapCache.containsKey(url)) {
-            onFetch.onFetch(bitmapCache.get(url));
-        } else {
-            Glide.with(context).load(url)
-                    .asBitmap()
-                    .skipMemoryCache(false)
-                    .placeholder(placeholderDrawable)
-                    .diskCacheStrategy(DiskCacheStrategy.ALL)
-                    .into(new SimpleTarget<Bitmap>(pxWidth, pxHeight) {
-                        @Override
-                        public void onResourceReady(Bitmap bitmap, GlideAnimation anim) {
-                            bitmapCache.put(url, bitmap);
-                            onFetch.onFetch(bitmap);
-                        }
-                    });
-        }
+        Glide.with(context).load(url)
+                .asBitmap()
+                .skipMemoryCache(false)
+                .placeholder(placeholderDrawable)
+                .diskCacheStrategy(DiskCacheStrategy.ALL)
+                .into(new SimpleTarget<Bitmap>(pxWidth, pxHeight) {
+                    @Override
+                    public void onResourceReady(Bitmap bitmap, GlideAnimation anim) {
+                        onFetch.onFetch(bitmap);
+                    }
+                });
     }
 
     public interface Callback {


### PR DESCRIPTION
For simplicity, image caching is now handled only by Glide.
