### PR TITLE
Niantic Api Scan Radius Change

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/helpers/MapHelper.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/helpers/MapHelper.java
@@ -1,7 +1,5 @@
 package com.omkarmoghe.pokemap.helpers;
 
-import android.util.Log;
-
 import com.google.android.gms.maps.model.LatLng;
 
 import java.util.ArrayList;
@@ -23,8 +21,8 @@ public class MapHelper {
     public static final float LAYER_GYMS = 150;
     public static final float LAYER_POKEMONS = 200;
 
-    private static final int DEFAULT_RADIUS = 100;
-    private static final double DISTANCE_BETWEEN_CIRCLES = 173.1;
+    public static final int SCAN_RADIUS = 70;
+    private static final double DISTANCE_BETWEEN_CIRCLES = 121;
 
     /**
      * Returns the distance from 'this' point to destination point (using haversine formula).
@@ -143,6 +141,6 @@ public class MapHelper {
 
 
     public static double convertStepsToRadius(int steps) {
-        return (steps - 1) * DISTANCE_BETWEEN_CIRCLES + DEFAULT_RADIUS;
+        return (steps - 1) * DISTANCE_BETWEEN_CIRCLES + SCAN_RADIUS;
     }
 }

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -737,7 +737,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
     private void drawCatchedPokemonCircle(double latitude, double longitude) {
 
         if (mGoogleMap != null && mPref.getShowScannedPlaces()) {
-            double radiusInMeters = 100.0;
+            double radiusInMeters = MapHelper.SCAN_RADIUS;
             int shadeColor = 0x44DCD90D; // fill
             CircleOptions circleOptions = new CircleOptions()
                     .center(new LatLng(latitude, longitude))


### PR DESCRIPTION
Due to Niantic changing the Scan Radius of catchable pokemon from 100 meters to 70 meters, some pokemon maybe missed from the scan even if the screen shows that area has been searched.
- Changes Scan Radius to 70m
- Change MapFragmentWrapper to draw the circle based on the Scan Radius in the MapHelper class.
