### PR TITLE
Fix  #343: Expired Pokémon don't get removed

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -596,12 +596,12 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
 
             @Override
             public void onAnimationEnd(Animator animator) {
+                pokemonMarker.getMarker().remove();
+                markerList.remove(pokemonMarker);
             }
 
             @Override
             public void onAnimationCancel(Animator animator) {
-                pokemonMarker.getMarker().remove();
-                markerList.remove(pokemonMarker);
             }
 
             @Override

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -589,19 +589,23 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
         ObjectAnimator animator = ObjectAnimator.ofFloat(pokemonMarker.getMarker(), "alpha", 1f, 0f);
         animator.setDuration(400);
         animator.addListener(new Animator.AnimatorListener() {
+            private boolean isCanceled;
             @Override
             public void onAnimationStart(Animator animator) {
-
+                isCanceled = false;
             }
 
             @Override
             public void onAnimationEnd(Animator animator) {
-                pokemonMarker.getMarker().remove();
-                markerList.remove(pokemonMarker);
+                if (!isCanceled) {
+                    removeExpiredPokeMarker(pokemonMarker);
+                }
             }
 
             @Override
             public void onAnimationCancel(Animator animator) {
+                isCanceled = true;
+                removeExpiredPokeMarker(pokemonMarker);
             }
 
             @Override
@@ -612,6 +616,10 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
         animator.start();
     }
 
+    private void removeExpiredPokeMarker(PokemonMarkerExtended pokemonMarker){
+        pokemonMarker.getMarker().remove();
+        markerList.remove(pokemonMarker);
+    }
 
     private void showMapNotInitializedError() {
         if(getView() != null){


### PR DESCRIPTION
The Pokémon gets removed only after the map refreshes. You can click away from the Pokémon and back on it again when it's expired/invisible.

Relate to https://github.com/omkarmoghe/Pokemap/issues/343 
