### PR TITLE
Pokestops now correctly display if they have an active lure module

### DIFF
--- a/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/controllers/net/NianticManager.java
@@ -20,6 +20,7 @@ import com.omkarmoghe.pokemap.models.events.PokestopsEvent;
 import com.omkarmoghe.pokemap.models.events.ServerUnreachableEvent;
 import com.omkarmoghe.pokemap.models.login.LoginInfo;
 import com.omkarmoghe.pokemap.models.login.PtcLoginInfo;
+import com.omkarmoghe.pokemap.util.PokestopUtil;
 import com.pokegoapi.api.PokemonGo;
 import com.pokegoapi.api.map.MapObjects;
 import com.pokegoapi.api.map.fort.Pokestop;
@@ -373,7 +374,7 @@ public class NianticManager {
 
                         List<CatchablePokemon> pokemon = new ArrayList<>();
                         for(Pokestop pokestop: mPokemonGo.getMap().getMapObjects().getPokestops()){
-                            if(!pokestop.getFortData().getLureInfo().equals(FortLureInfoOuterClass.FortLureInfo.getDefaultInstance())){
+                            if(PokestopUtil.hasLuredPokemon(pokestop)){
                                 Log.d(TAG, "run: hasFortInfo = " + pokestop.getFortData().getLureInfo());
                                 pokemon.add(new CatchablePokemon(mPokemonGo, pokestop.getFortData()));
                             }

--- a/app/src/main/java/com/omkarmoghe/pokemap/util/PokestopUtil.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/util/PokestopUtil.java
@@ -1,0 +1,15 @@
+package com.omkarmoghe.pokemap.util;
+
+import com.pokegoapi.api.map.fort.Pokestop;
+
+/**
+ * Created by chris on 7/30/2016.
+ */
+
+public class PokestopUtil {
+
+    public static boolean hasLuredPokemon(Pokestop pokestop){
+        return pokestop.getFortData().hasLureInfo()
+                && pokestop.getFortData().getLureInfo().getLureExpiresTimestampMs() > System.currentTimeMillis();
+    }
+}

--- a/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
+++ b/app/src/main/java/com/omkarmoghe/pokemap/views/map/MapWrapperFragment.java
@@ -53,6 +53,7 @@ import com.omkarmoghe.pokemap.models.map.GymMarkerExtended;
 import com.omkarmoghe.pokemap.models.map.PokemonMarkerExtended;
 import com.omkarmoghe.pokemap.models.map.PokestopMarkerExtended;
 import com.omkarmoghe.pokemap.util.PokemonIdUtils;
+import com.omkarmoghe.pokemap.util.PokestopUtil;
 import com.omkarmoghe.pokemap.views.MainActivity;
 import com.pokegoapi.api.map.fort.Pokestop;
 import com.pokegoapi.api.map.pokemon.CatchablePokemon;
@@ -347,7 +348,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                     int markerSize = getResources().getDimensionPixelSize(R.dimen.pokestop_marker);
 
                     RemoteImageLoader.loadMapIcon(
-                            getActivity(), pokestop.hasLurePokemon() ? lurePokeStopImageUrl : pokeStopImageUrl,
+                            getActivity(), PokestopUtil.hasLuredPokemon(pokestop) ? lurePokeStopImageUrl : pokeStopImageUrl,
                         markerSize, markerSize,
                             new RemoteImageLoader.Callback() {
                             @Override
@@ -355,7 +356,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
 
                                 BitmapDescriptor bitmapDescriptor = BitmapDescriptorFactory.fromBitmap(bitmap);
                                 marker.setIcon(bitmapDescriptor);
-                                marker.setZIndex(pokestop.hasLurePokemon() ? 1.0f : 0.5f);
+                                marker.setZIndex(PokestopUtil.hasLuredPokemon(pokestop) ? 1.0f : 0.5f);
                             }
                         }
                     );
@@ -427,7 +428,7 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                     if (!markerKeys.contains(pokestop.getId()) && distanceFromCenterInMeters <= MapHelper.convertStepsToRadius(mPref.getSteps())) {
 
                             RemoteImageLoader.loadMapIcon(
-                                    getActivity(), pokestop.hasLurePokemon() ? lurePokeStopImageUrl : pokeStopImageUrl,
+                                    getActivity(), PokestopUtil.hasLuredPokemon(pokestop) ? lurePokeStopImageUrl : pokeStopImageUrl,
                             markerSize, markerSize,
                                     new RemoteImageLoader.Callback() {
                                 @Override
@@ -440,8 +441,8 @@ public class MapWrapperFragment extends Fragment implements OnMapReadyCallback,
                                         .title(getString(R.string.pokestop))
                                         .icon(bitmapDescriptor)
                                         .zIndex(MapHelper.LAYER_POKESTOPS)
-                                        .alpha(pokestop.hasLurePokemon() ? 1.0f : 0.5f)
-                                        .anchor(0.5f, 0.5f));
+                                        .alpha(PokestopUtil.hasLuredPokemon(pokestop) ? 1.0f : 0.5f)
+                                        .anchor(0.5f, 0.95f));
 
                                     //adding pokemons to list to be removed on next search
                                     pokestopsList.put(pokestop.getId(), new PokestopMarkerExtended(pokestop, marker));


### PR DESCRIPTION
- Added in PokestopUtil
- Pokestops with active lures now correctly show up as lured Pokestops
- The bottom point of a Pokestop now reflects where it actually is in real life, like in Pokemon Go.
